### PR TITLE
Throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,13 @@ after a single breach of the limit until the next restart of fluentd.
 
 A value of `-1` disables the feature.
 
-#### group\_warning\_hz
+#### group\_warning\_delay\_s
 
-Default: `0.1` (10 seconds).
+Default: `10` (seconds).
 
 When a group reaches its limit and as long as it is not reset, a warning
-message with the current log rate for the group is logged at this frequency.
+message with the current log rate of the group is emitted repeatedly. This is
+the delay between every repetition.
 
 ## Copyright
 

--- a/fluent-plugin-throttle.gemspec
+++ b/fluent-plugin-throttle.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-throttle"
-  spec.version       = "0.0.2"
+  spec.version       = "0.0.3"
   spec.authors       = ["François-Xavier Bourlet"]
   spec.email         = ["fx.bourlet@rubrik.com"]
   spec.summary       = %q{Fluentd filter for throttling logs based on a configurable key.}

--- a/lib/fluent/plugin/filter_throttle.rb
+++ b/lib/fluent/plugin/filter_throttle.rb
@@ -1,0 +1,139 @@
+require 'fluent/filter'
+
+module Fluent
+  class ThrottleFilter < Filter
+    Fluent::Plugin.register_filter('throttle', self)
+
+    config_param :group_key, :string, :default => 'kubernetes.container_name'
+    config_param :group_bucket_period_s, :integer, :default => 60
+    config_param :group_bucket_limit, :integer, :default => 6000
+    config_param :group_reset_rate_s, :integer, :default => nil
+    config_param :warning_hz, :float, :default => 0.1
+
+    Bucket = Struct.new(:emitted, :last_reset)
+    Group = Struct.new(
+      :rate_count,
+      :rate_last_reset,
+      :rate,
+      :bucket_count,
+      :bucket_last_reset,
+      :last_warning)
+
+    def configure(conf)
+      super
+
+      @group_key_path = group_key.split(".")
+
+      raise "group_bucket_period_s must be > 0" \
+        unless @group_bucket_period_s > 0
+
+      raise "group_bucket_limit must be > 0" \
+        unless @group_bucket_limit > 0
+
+      @group_rate_limit = (@group_bucket_limit / @group_bucket_period_s)
+
+      @group_reset_rate_s = @group_rate_limit \
+        if @group_reset_rate_s == nil
+
+      raise "group_reset_rate_s must be >= -1" \
+        unless @group_reset_rate_s >= -1
+      raise "group_reset_rate_s must be <= group_bucket_limit / group_bucket_period_s" \
+        unless @group_reset_rate_s <= @group_rate_limit
+
+      @warning_delay = (1.0 / @warning_hz)
+    end
+
+    def start
+      super
+
+      @counters = Hash.new()
+    end
+
+    def shutdown
+      $log.info("counters summary: #{@counters}")
+      super
+    end
+
+    def filter(tag, time, record)
+      now = Time.now
+      group = extract_group(record)
+      counter = @counters.fetch(group, nil)
+      counter = @counters[group] = Group.new(
+        0, now, 0, 0, now, nil) if counter == nil
+
+      counter.rate_count += 1
+
+      since_last_rate_reset = now - counter.rate_last_reset
+      if since_last_rate_reset >= 1
+        # compute and store rate/s at most every seconds.
+        counter.rate = (counter.rate_count / since_last_rate_reset).round()
+        counter.rate_count = 0
+        counter.rate_last_reset = now
+      end
+
+      if (now.to_i / @group_bucket_period_s) \
+          > (counter.bucket_last_reset.to_i / @group_bucket_period_s)
+        # next time period reached, reset limit.
+
+        if counter.bucket_count == -1 and @group_reset_rate_s != -1
+          # wait until rate drops back down if needed.
+          if counter.rate < @group_reset_rate_s
+            log_rate_back_down(now, group, counter)
+          else
+            since_last_warning = now - counter.last_warning
+            if since_last_warning > @warning_delay
+              log_rate_limit_exceeded(now, group, counter)
+              counter.last_warning = now
+            end
+            return nil
+          end
+        end
+
+        counter.bucket_count = 0
+        counter.bucket_last_reset = now
+      end
+
+      if counter.bucket_count == -1
+        return nil
+      end
+
+      counter.bucket_count += 1
+
+      if counter.bucket_count > @group_bucket_limit
+        log_rate_limit_exceeded(now, group, counter)
+        counter.last_warning = now
+        counter.bucket_count = -1
+        return nil
+      end
+
+      record
+    end
+
+    def extract_group(record)
+      record.dig(*@group_key_path)
+    end
+
+    def log_rate_limit_exceeded(now, group, counter)
+      $log.warn("rate exceeded", log_items(now, group, counter))
+    end
+
+    def log_rate_back_down(now, group, counter)
+      $log.info("rate back down", log_items(now, group, counter))
+    end
+
+    def log_items(now, group, counter)
+      rate = counter.rate
+      if rate == 0
+        since_last_reset = now - counter.bucket_last_reset
+        rate = (counter.bucket_count / since_last_reset).round()
+      end
+
+      {'group_key': group,
+       'rate_s': rate,
+       'period_s': @group_bucket_period_s,
+       'limit': @group_bucket_limit,
+       'rate_limit_s': @group_rate_limit,
+       'reset_rate_s': @group_reset_rate_s}
+    end
+  end
+end

--- a/lib/fluent/plugin/filter_throttle.rb
+++ b/lib/fluent/plugin/filter_throttle.rb
@@ -10,7 +10,6 @@ module Fluent
     config_param :group_reset_rate_s, :integer, :default => nil
     config_param :warning_hz, :float, :default => 0.1
 
-    Bucket = Struct.new(:emitted, :last_reset)
     Group = Struct.new(
       :rate_count,
       :rate_last_reset,


### PR DESCRIPTION
Add throttling support.

Implementation is some sort of leaky bucket. Configuration allows to set how many logs are allowed for a specific time period.

Refer to [README.md](/rubrikinc/fluent-plugin-throttle/blob/master/README.md) for some extra documentation.