### PR TITLE
Add a logging-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ When a group reaches its limit and as long as it is not reset, a warning
 message with the current log rate of the group is emitted repeatedly. This is
 the delay between every repetition.
 
+#### log_only
+
+Default: `false`.
+
+When a group reaches its limit, only a warning message will be emitted and no
+logs will actually be dropped. This can be useful to fine-tune your group
+bucket limits before dropping any logs.
+
 ## Copyright
 
 Copyright © 2018 ([Rubrik Inc.](https://www.rubrik.com))

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ logs per minute. However `60/60s` will readily emit 60 logs within the first
 second then nothing for the remaining 59 seconds. While the `1/1s` will only
 emit the first log of every second.
 
+#### group\_drop\_logs
+
+Default: `true`.
+
+When a group reaches its limit, logs will be dropped from further processing
+if this value is true (set by default). To prevent the logs from being dropped
+and only receive a warning message when rate limiting would have occurred, set
+this value for false. This can be useful to fine-tune your group bucket limits
+before dropping any logs.
+
 #### group\_reset\_rate\_s
 
 Default: `group_bucket_limit/group_bucket_period_s` (logs per `group_bucket_period_s`).
@@ -116,14 +126,6 @@ Default: `10` (seconds).
 When a group reaches its limit and as long as it is not reset, a warning
 message with the current log rate of the group is emitted repeatedly. This is
 the delay between every repetition.
-
-#### log_only
-
-Default: `false`.
-
-When a group reaches its limit, only a warning message will be emitted and no
-logs will actually be dropped. This can be useful to fine-tune your group
-bucket limits before dropping any logs.
 
 ## Copyright
 

--- a/lib/fluent/plugin/filter_throttle.rb
+++ b/lib/fluent/plugin/filter_throttle.rb
@@ -108,6 +108,8 @@ module Fluent::Plugin
       record
     end
 
+    private
+
     def extract_group(record)
       record.dig(*@group_key_path) || record.dig(*@group_key_path.map(&:to_sym))
     end

--- a/lib/fluent/plugin/filter_throttle.rb
+++ b/lib/fluent/plugin/filter_throttle.rb
@@ -127,7 +127,7 @@ module Fluent::Plugin
 
     def log_items(now, group, counter)
       since_last_reset = now - counter.bucket_last_reset
-      rate = (counter.bucket_count / since_last_reset).round()
+      rate = since_last_reset > 0 ? (counter.bucket_count / since_last_reset).round : Float::INFINITY
       aprox_rate = counter.aprox_rate
       rate = aprox_rate if aprox_rate > rate
 

--- a/lib/fluent/plugin/filter_throttle.rb
+++ b/lib/fluent/plugin/filter_throttle.rb
@@ -1,13 +1,35 @@
+# frozen_string_literal: true
 require 'fluent/plugin/filter'
 
 module Fluent::Plugin
   class ThrottleFilter < Filter
     Fluent::Plugin.register_filter('throttle', self)
 
+    desc "Used to group logs. Groups are rate limited independently"
     config_param :group_key, :string, :default => 'kubernetes.container_name'
+
+    desc <<~DESC
+      This is the period of of time over which group_bucket_limit applies
+    DESC
     config_param :group_bucket_period_s, :integer, :default => 60
+
+    desc <<~DESC
+      Maximum number logs allowed per groups over the period of
+      group_bucket_period_s
+    DESC
     config_param :group_bucket_limit, :integer, :default => 6000
+
+    desc <<~DESC
+      After a group has exceeded its bucket limit, logs are dropped until the
+      rate per second falls below or equal to group_reset_rate_s.
+    DESC
     config_param :group_reset_rate_s, :integer, :default => nil
+
+    desc <<~DESC
+      When a group reaches its limit and as long as it is not reset, a warning
+      message with the current log rate of the group is emitted repeatedly.
+      This is the delay between every repetition.
+    DESC
     config_param :group_warning_delay_s, :integer, :default => 10
 
     Group = Struct.new(

--- a/test/fluent/plugin/filter_throttle_test.rb
+++ b/test/fluent/plugin/filter_throttle_test.rb
@@ -11,8 +11,14 @@ describe Fluent::Plugin::ThrottleFilter do
     Fluent::Test.setup
   end
 
+  after do
+    if instance_variable_defined?(:@driver)
+      assert @driver.error_events.empty?, "Errors detected: " + @driver.error_events.map(&:inspect).join("\n")
+    end
+  end
+
   def create_driver(conf='')
-    Fluent::Test::Driver::Filter.new(Fluent::Plugin::ThrottleFilter).configure(conf)
+    @driver = Fluent::Test::Driver::Filter.new(Fluent::Plugin::ThrottleFilter).configure(conf)
   end
 
   describe '#configure' do
@@ -106,7 +112,7 @@ describe Fluent::Plugin::ThrottleFilter do
         end
       end
 
-      assert_equal 3, driver.logs.select { |log| log.include?('rate exceeded') }.size
+      assert_equal 4, driver.logs.select { |log| log.include?('rate exceeded') }.size
     end
 
     it 'logs when rate drops below group_reset_rate_s' do

--- a/test/fluent/plugin/filter_throttle_test.rb
+++ b/test/fluent/plugin/filter_throttle_test.rb
@@ -123,7 +123,7 @@ describe Fluent::Plugin::ThrottleFilter do
         group_bucket_period_s 2
         group_bucket_limit 4
         group_reset_rate_s 2
-        log_only true
+        group_drop_logs false
       CONF
 
       records_expected = 0


### PR DESCRIPTION
Add a logging only mode to prevent dropping logs while tuning the group_bucket_limit.

/cc @bombela