### PR TITLE
Fix memory issue with fluent throttler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fluent-plugin-throttle (0.0.3)
+    fluent-plugin-throttle (0.0.5)
       fluentd (~> 1.1)
 
 GEM
@@ -15,19 +15,18 @@ GEM
       thor (>= 0.14.0)
     byebug (10.0.2)
     coderay (1.1.2)
-    cool.io (1.5.3)
+    concurrent-ruby (1.1.6)
+    cool.io (1.6.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    dig_rb (1.0.1)
-    fluentd (1.2.3)
+    fluentd (1.11.1)
       cool.io (>= 1.4.5, < 2.0.0)
-      dig_rb (~> 1.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
-      msgpack (>= 0.7.0, < 2.0.0)
+      msgpack (>= 1.3.1, < 2.0.0)
       serverengine (>= 2.0.4, < 3.0.0)
       sigdump (~> 0.2.2)
       strptime (>= 0.2.2, < 1.0.0)
-      tzinfo (~> 1.0)
+      tzinfo (>= 1.0, < 3.0)
       tzinfo-data (~> 1.0)
       yajl-ruby (~> 1.0)
     hashdiff (0.3.7)
@@ -39,7 +38,7 @@ GEM
     minitest (5.11.3)
     mocha (1.6.0)
       metaclass (~> 0.0.1)
-    msgpack (1.2.4)
+    msgpack (1.3.3)
     power_assert (1.1.3)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -50,18 +49,17 @@ GEM
     public_suffix (3.0.2)
     rake (12.3.1)
     safe_yaml (1.0.4)
-    serverengine (2.0.7)
+    serverengine (2.2.1)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     single_cov (1.1.0)
-    strptime (0.2.3)
+    strptime (0.2.4)
     test-unit (3.2.8)
       power_assert
     thor (0.20.0)
-    thread_safe (0.3.6)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
-    tzinfo-data (1.2018.5)
+    tzinfo (2.0.2)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2020.1)
       tzinfo (>= 1.0.0)
     webmock (3.4.2)
       addressable (>= 2.3.6)
@@ -86,4 +84,4 @@ DEPENDENCIES
   webmock (~> 3.3)
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/rubrikinc/fluent-plugin-throttle/blob/master/LICENSE)
 
-A sentry pluging to throttle logs. Logs are grouped by a configurable key. When
+A sentry plugin to throttle logs. Logs are grouped by a configurable key. When
 a group exceeds a configuration rate, logs are dropped for this group.
 
 ## Installation

--- a/fluent-plugin-throttle.gemspec
+++ b/fluent-plugin-throttle.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-throttle"
-  spec.version       = "0.0.3"
+  spec.version       = "0.0.5"
   spec.authors       = ["François-Xavier Bourlet"]
   spec.email         = ["fx.bourlet@rubrik.com"]
   spec.summary       = %q{Fluentd filter for throttling logs based on a configurable key.}


### PR DESCRIPTION
## Description
The throttler filter never removes inactive groups from the counter hash. This fix **implements LRU eviction** to remove inactive groups in order to relieve memory usage. **Eviction is attempted every time a new event arrives** so that the hash can decrease in size and not increase indefinitely. 

## Testing Performed:
Fluentd was configured to use the fluent-plugin-throttle filter and read json logs from a file. 

### Throttler before fix
**1,000,000 unique logs**
cpu time: 00:27.40
RSS: 429.4 MB

**2,000,000 unique logs**
cpu time: 01:08.36
RSS: 784.3 MB

### Throttler after fix
**1,000,000 unique logs**
cpu time: 00:35.95
RSS: 160.1 MB

**2,000,000 unique logs**
cpu time: 01:11.96
RSS: 161.5 MB

LRU eviction was tested and verified through the debug logs when running fluentd on verbose mode.